### PR TITLE
fix(fe): fixed info div error

### DIFF
--- a/client/src/components/AddMap.tsx
+++ b/client/src/components/AddMap.tsx
@@ -87,7 +87,7 @@ const AddMap = ({
 
       for (let i = 0; i < result.length; i += 1) {
         // 행정동의 region_type 값은 'H' 이므로
-        if (result[i].region_type === 'H') {
+        if (result[i].region_type === 'H' && infoDiv) {
           infoDiv!.innerHTML = result[i].address_name;
           break;
         }

--- a/client/src/components/KakaoMapAdd.tsx
+++ b/client/src/components/KakaoMapAdd.tsx
@@ -57,7 +57,7 @@ const KakaoMapAdd = ({
 
       for (let i = 0; i < result.length; i += 1) {
         // 행정동의 region_type 값은 'H' 이므로
-        if (result[i].region_type === 'H') {
+        if (result[i].region_type === 'H' && infoDiv) {
           infoDiv!.innerHTML = result[i].address_name;
           break;
         }


### PR DESCRIPTION
Close #3 

TypeError: Cannot set properties of null (setting 'innerHTML')
    at displayCenterInfo (http://localhost:3000/static/js/bundle.js:480:29)
    at http://t1.daumcdn.net/mapjsapi/js/libs/services/1.0.2/services.js:6:1859
    at Object.oncomplete (http://t1.daumcdn.net/mapjsapi/js/libs/services/1.0.2/services.js:6:194)
    at a.onreadystatechange (http://t1.daumcdn.net/mapjsapi/js/libs/services/1.0.2/services.js:5:328)
-> checked if infoDiv is null before infoDiv!.innerHTML = result[i].address_name;